### PR TITLE
Fix pinned settings persistence and add configurable pinned-section UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ data.json
 
 # Distribution directory
 dist
+.codex/config.toml

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Go to **Settings → Community plugins → Pin to Top** to:
 - Unpin individual items
 - Clear all pins at once
 - Toggle the "Pinned" header label
+- Keep pinned items visible while scrolling
 - Toggle the pin icon before pinned items at the top of the file explorer
 - Toggle the pin icon after pinned items in the main file explorer
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Go to **Settings → Community plugins → Pin to Top** to:
 - View all pinned items
 - Unpin individual items
 - Clear all pins at once
+- Toggle the pin icon before pinned items at the top of the file explorer
+- Toggle the pin icon after pinned items in the main file explorer
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Go to **Settings → Community plugins → Pin to Top** to:
 - View all pinned items
 - Unpin individual items
 - Clear all pins at once
+- Toggle the "Pinned" header label
 - Toggle the pin icon before pinned items at the top of the file explorer
 - Toggle the pin icon after pinned items in the main file explorer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pin-to-top",
-	"version": "1.0.0",
+	"version": "1.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pin-to-top",
-			"version": "1.0.0",
+			"version": "1.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"obsidian": "latest"

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,13 @@ export default class PinPlugin extends Plugin {
 			})
 		);
 
+		// Update active state when the active file changes
+		this.registerEvent(
+			this.app.workspace.on("file-open", () => {
+				this.pinManager.updateActiveStates();
+			})
+		);
+
 		// Initial refresh after a short delay to ensure file explorer is loaded
 		this.app.workspace.onLayoutReady(() => {
 			setTimeout(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,8 @@ export default class PinPlugin extends Plugin {
 
 		document.body.classList.remove(
 			"pin-to-top-show-pinned-top-icon",
-			"pin-to-top-show-main-explorer-pin-icon"
+			"pin-to-top-show-main-explorer-pin-icon",
+			"pin-to-top-keep-pinned-items-visible"
 		);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export default class PinPlugin extends Plugin {
 
 		// Initialize pin manager
 		this.pinManager = new PinManager(this.app, this);
+		this.pinManager.applyExplorerDisplaySettings();
 
 		// Add settings tab
 		this.addSettingTab(new PinSettingTab(this.app, this));
@@ -143,6 +144,11 @@ export default class PinPlugin extends Plugin {
 		// Remove pinned classes
 		const pinnedItems = document.querySelectorAll(".pin-to-top-pinned");
 		pinnedItems.forEach((item) => item.classList.remove("pin-to-top-pinned"));
+
+		document.body.classList.remove(
+			"pin-to-top-show-pinned-top-icon",
+			"pin-to-top-show-main-explorer-pin-icon"
+		);
 	}
 
 	async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,9 +13,6 @@ export default class PinPlugin extends Plugin {
 		// Initialize pin manager
 		this.pinManager = new PinManager(this.app, this);
 
-		// Clean up any deleted items on load
-		await this.pinManager.cleanupDeletedItems();
-
 		// Add settings tab
 		this.addSettingTab(new PinSettingTab(this.app, this));
 

--- a/src/pin-manager.ts
+++ b/src/pin-manager.ts
@@ -30,6 +30,20 @@ export class PinManager {
 	}
 
 	/**
+	 * Apply settings-driven display classes for pin icons.
+	 */
+	applyExplorerDisplaySettings(): void {
+		document.body.classList.toggle(
+			"pin-to-top-show-pinned-top-icon",
+			this.plugin.settings.showPinnedTopIcon
+		);
+		document.body.classList.toggle(
+			"pin-to-top-show-main-explorer-pin-icon",
+			this.plugin.settings.showMainExplorerPinIcon
+		);
+	}
+
+	/**
 	 * Check if an item is pinned
 	 */
 	isPinned(path: string): boolean {
@@ -102,6 +116,8 @@ export class PinManager {
 	 * Refresh the file explorer to show pinned items at top
 	 */
 	refreshFileExplorer(): void {
+		this.applyExplorerDisplaySettings();
+
 		const leaves = this.getFileExplorerLeaves();
 
 		for (const leaf of leaves) {

--- a/src/pin-manager.ts
+++ b/src/pin-manager.ts
@@ -44,6 +44,41 @@ export class PinManager {
 	}
 
 	/**
+	 * Update active state for all file explorer pinned containers
+	 */
+	updateActiveStates(): void {
+		const leaves = this.getFileExplorerLeaves();
+		for (const leaf of leaves) {
+			const container = leaf.view.containerEl;
+			const pinnedContainer = container.querySelector(`.${PINNED_CONTAINER_CLASS}`);
+			if (pinnedContainer instanceof HTMLElement) {
+				this.updateActiveState(pinnedContainer);
+			}
+		}
+	}
+
+	/**
+	 * Update active state in a specific pinned container
+	 */
+	private updateActiveState(container: HTMLElement): void {
+		const activeFile = this.app.workspace.getActiveFile();
+		const activePath = activeFile?.path;
+
+		container.querySelectorAll(".pin-to-top-item.is-active").forEach((el) => {
+			el.classList.remove("is-active");
+		});
+
+		if (activePath) {
+			const activeItem = container.querySelector(
+				`.pin-to-top-item[data-path="${CSS.escape(activePath)}"]`
+			);
+			if (activeItem) {
+				activeItem.classList.add("is-active");
+			}
+		}
+	}
+
+	/**
 	 * Check if an item is pinned
 	 */
 	isPinned(path: string): boolean {
@@ -166,6 +201,19 @@ export class PinManager {
 		const pinnedContainer = document.createElement("div");
 		pinnedContainer.classList.add(PINNED_CONTAINER_CLASS);
 
+		// Add section header
+		const header = document.createElement("div");
+		header.classList.add("pin-to-top-header");
+		const headerIcon = document.createElement("span");
+		headerIcon.classList.add("pin-to-top-header-icon");
+		setIcon(headerIcon, "pin");
+		header.appendChild(headerIcon);
+		const headerText = document.createElement("span");
+		headerText.classList.add("pin-to-top-header-text");
+		headerText.textContent = "Pinned";
+		header.appendChild(headerText);
+		pinnedContainer.appendChild(header);
+
 		// Create pinned item elements (not clones - custom lightweight elements)
 		for (const path of pinnedPaths) {
 			const file = this.app.vault.getAbstractFileByPath(path);
@@ -180,6 +228,9 @@ export class PinManager {
 				originalItem.classList.add(PINNED_CLASS);
 			}
 		}
+
+		// Update active state
+		this.updateActiveState(pinnedContainer);
 
 		// Insert pinned container at the top
 		navFilesContainer.insertBefore(pinnedContainer, navFilesContainer.firstChild);

--- a/src/pin-manager.ts
+++ b/src/pin-manager.ts
@@ -41,6 +41,10 @@ export class PinManager {
 			"pin-to-top-show-main-explorer-pin-icon",
 			this.plugin.settings.showMainExplorerPinIcon
 		);
+		document.body.classList.toggle(
+			"pin-to-top-keep-pinned-items-visible",
+			this.plugin.settings.keepPinnedItemsVisible
+		);
 	}
 
 	/**

--- a/src/pin-manager.ts
+++ b/src/pin-manager.ts
@@ -264,10 +264,10 @@ export class PinManager {
 			titleEl.appendChild(collapseIcon);
 		}
 
-		// Add file/folder icon
+		// Add file/folder label
 		const iconEl = document.createElement("div");
 		iconEl.classList.add(isFolder ? "nav-folder-title-content" : "nav-file-title-content");
-		iconEl.textContent = file.name;
+		iconEl.textContent = this.getPinnedItemDisplayName(file);
 		titleEl.appendChild(iconEl);
 
 		wrapper.appendChild(titleEl);
@@ -348,6 +348,17 @@ export class PinManager {
 		this.addDragDropHandlers(wrapper, file.path);
 
 		return wrapper;
+	}
+
+	/**
+	 * Get the label shown for a pinned item.
+	 */
+	private getPinnedItemDisplayName(file: TAbstractFile): string {
+		if (file instanceof TFile) {
+			return file.basename;
+		}
+
+		return file.name;
 	}
 
 	/**

--- a/src/pin-manager.ts
+++ b/src/pin-manager.ts
@@ -201,18 +201,20 @@ export class PinManager {
 		const pinnedContainer = document.createElement("div");
 		pinnedContainer.classList.add(PINNED_CONTAINER_CLASS);
 
-		// Add section header
-		const header = document.createElement("div");
-		header.classList.add("pin-to-top-header");
-		const headerIcon = document.createElement("span");
-		headerIcon.classList.add("pin-to-top-header-icon");
-		setIcon(headerIcon, "pin");
-		header.appendChild(headerIcon);
-		const headerText = document.createElement("span");
-		headerText.classList.add("pin-to-top-header-text");
-		headerText.textContent = "Pinned";
-		header.appendChild(headerText);
-		pinnedContainer.appendChild(header);
+		// Add section header when enabled
+		if (this.plugin.settings.showPinnedHeaderLabel) {
+			const header = document.createElement("div");
+			header.classList.add("pin-to-top-header");
+			const headerIcon = document.createElement("span");
+			headerIcon.classList.add("pin-to-top-header-icon");
+			setIcon(headerIcon, "pin");
+			header.appendChild(headerIcon);
+			const headerText = document.createElement("span");
+			headerText.classList.add("pin-to-top-header-text");
+			headerText.textContent = "Pinned";
+			header.appendChild(headerText);
+			pinnedContainer.appendChild(header);
+		}
 
 		// Create pinned item elements (not clones - custom lightweight elements)
 		for (const path of pinnedPaths) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -75,6 +75,20 @@ export class PinSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// Sticky pinned items setting
+		new Setting(containerEl)
+			.setName("Keep pinned items visible while scrolling")
+			.setDesc("Keep the pinned section stuck to the top of the file explorer while you scroll.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.keepPinnedItemsVisible)
+					.onChange(async (value) => {
+						this.plugin.settings.keepPinnedItemsVisible = value;
+						await this.plugin.saveSettings();
+						this.plugin.pinManager.refreshFileExplorer();
+					})
+			);
+
 		// Display pinned items count
 		new Setting(containerEl)
 			.setName("Pinned items")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,6 +33,34 @@ export class PinSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// Pinned-top icon setting
+		new Setting(containerEl)
+			.setName("Show pin icon for pinned items")
+			.setDesc("Display the pin icon before items pinned at the top of the file explorer.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showPinnedTopIcon)
+					.onChange(async (value) => {
+						this.plugin.settings.showPinnedTopIcon = value;
+						await this.plugin.saveSettings();
+						this.plugin.pinManager.applyExplorerDisplaySettings();
+					})
+			);
+
+		// Main explorer icon setting
+		new Setting(containerEl)
+			.setName("Show pin icon for main explorer items")
+			.setDesc("Display the pin icon after items in the main file explorer.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showMainExplorerPinIcon)
+					.onChange(async (value) => {
+						this.plugin.settings.showMainExplorerPinIcon = value;
+						await this.plugin.saveSettings();
+						this.plugin.pinManager.applyExplorerDisplaySettings();
+					})
+			);
+
 		// Display pinned items count
 		new Setting(containerEl)
 			.setName("Pinned items")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,7 +43,7 @@ export class PinSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.showPinnedTopIcon = value;
 						await this.plugin.saveSettings();
-						this.plugin.pinManager.applyExplorerDisplaySettings();
+						this.plugin.pinManager.refreshFileExplorer();
 					})
 			);
 
@@ -57,7 +57,21 @@ export class PinSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.showMainExplorerPinIcon = value;
 						await this.plugin.saveSettings();
-						this.plugin.pinManager.applyExplorerDisplaySettings();
+						this.plugin.pinManager.refreshFileExplorer();
+					})
+			);
+
+		// Pinned header label setting
+		new Setting(containerEl)
+			.setName("Show pinned header label")
+			.setDesc("Display the pinned header above pinned items at the top of the file explorer.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.showPinnedHeaderLabel)
+					.onChange(async (value) => {
+						this.plugin.settings.showPinnedHeaderLabel = value;
+						await this.plugin.saveSettings();
+						this.plugin.pinManager.refreshFileExplorer();
 					})
 			);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface PinPluginSettings {
 	showMainExplorerPinIcon: boolean;
 	/** Show the "Pinned" label in the pinned header */
 	showPinnedHeaderLabel: boolean;
+	/** Keep pinned items visible at the top while scrolling */
+	keepPinnedItemsVisible: boolean;
 }
 
 /**
@@ -32,4 +34,5 @@ export const DEFAULT_SETTINGS: PinPluginSettings = {
 	showPinnedTopIcon: true,
 	showMainExplorerPinIcon: true,
 	showPinnedHeaderLabel: true,
+	keepPinnedItemsVisible: false,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,10 @@ export interface PinPluginSettings {
 	pinnedItems: string[];
 	/** Automatically expand folders when clicking pinned folder items */
 	autoExpandFolders: boolean;
+	/** Show the pin icon before items pinned at the top */
+	showPinnedTopIcon: boolean;
+	/** Show the pin icon after items in the main explorer */
+	showMainExplorerPinIcon: boolean;
 }
 
 /**
@@ -23,4 +27,6 @@ export interface FileExplorerView {
 export const DEFAULT_SETTINGS: PinPluginSettings = {
 	pinnedItems: [],
 	autoExpandFolders: true,
+	showPinnedTopIcon: true,
+	showMainExplorerPinIcon: true,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface PinPluginSettings {
 	showPinnedTopIcon: boolean;
 	/** Show the pin icon after items in the main explorer */
 	showMainExplorerPinIcon: boolean;
+	/** Show the "Pinned" label in the pinned header */
+	showPinnedHeaderLabel: boolean;
 }
 
 /**
@@ -29,4 +31,5 @@ export const DEFAULT_SETTINGS: PinPluginSettings = {
 	autoExpandFolders: true,
 	showPinnedTopIcon: true,
 	showMainExplorerPinIcon: true,
+	showPinnedHeaderLabel: true,
 };

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,13 @@
 		box-shadow 0.2s ease;
 }
 
+body.pin-to-top-keep-pinned-items-visible .pin-to-top-container {
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	background-color: var(--background-primary);
+}
+
 /* ===== Section Header ===== */
 .pin-to-top-header {
 	display: flex;

--- a/styles.css
+++ b/styles.css
@@ -12,8 +12,14 @@
 }
 
 /* Add pin icon only to direct pinned items (not nested content) */
-.pin-to-top-container > .pin-to-top-item > .nav-file-title::before,
-.pin-to-top-container > .pin-to-top-item > .nav-folder-title::before {
+body.pin-to-top-show-pinned-top-icon
+	.pin-to-top-container
+	> .pin-to-top-item
+	> .nav-file-title::before,
+body.pin-to-top-show-pinned-top-icon
+	.pin-to-top-container
+	> .pin-to-top-item
+	> .nav-folder-title::before {
 	content: "";
 	display: inline-block;
 	width: 14px;
@@ -71,8 +77,13 @@
 
 /* Mark original pinned items with a subtle indicator */
 /* Works for both items in folders and root-level items */
-.pin-to-top-pinned > .nav-file-title .nav-file-title-content::after,
-.pin-to-top-pinned > .nav-folder-title::after {
+body.pin-to-top-show-main-explorer-pin-icon
+	.pin-to-top-pinned
+	> .nav-file-title
+	.nav-file-title-content::after,
+body.pin-to-top-show-main-explorer-pin-icon
+	.pin-to-top-pinned
+	> .nav-folder-title::after {
 	content: "";
 	display: inline-block;
 	width: 10px;

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,154 @@
 /*
- * Pin to Top Plugin Styles
- * 
- * Styles for pinned items in the file explorer
+ * Pin to Top Plugin - Premium Theme-Aware Styles
+ *
+ * Elegant, modern styling that adapts seamlessly to any Obsidian theme.
  */
 
-/* Pinned items container at the top of file explorer */
+/* ===== Container ===== */
 .pin-to-top-container {
-	border-bottom: 1px solid var(--background-modifier-border);
-	padding-bottom: 4px;
-	margin-bottom: 4px;
+	position: relative;
+	margin-bottom: 8px;
+	transition:
+		border-color 0.2s ease,
+		box-shadow 0.2s ease;
 }
 
-/* Add pin icon only to direct pinned items (not nested content) */
+/* ===== Section Header ===== */
+.pin-to-top-header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 6px 10px;
+	margin: -2px -2px 4px;
+	font-size: var(--font-ui-smaller, 11px);
+	font-weight: 700;
+	color: var(--text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	user-select: none;
+	border-bottom: 1px solid var(--background-modifier-border);
+	opacity: 0.75;
+	transition: opacity 0.2s ease;
+}
+
+.pin-to-top-container:hover .pin-to-top-header {
+	opacity: 1;
+}
+
+.pin-to-top-header-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 13px;
+	height: 13px;
+	color: var(--text-accent);
+}
+
+.pin-to-top-header-icon svg {
+	width: 100%;
+	height: 100%;
+	stroke-width: 2.5px;
+}
+
+/* ===== Individual Pinned Items ===== */
+.pin-to-top-item {
+	position: relative;
+	cursor: pointer;
+	margin-bottom: 2px;
+	transition: transform 0.15s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.pin-to-top-item:last-child {
+	margin-bottom: 0;
+}
+
+.pin-to-top-item > .nav-file-title,
+.pin-to-top-item > .nav-folder-title {
+	display: flex;
+	align-items: center;
+	padding: 5px 8px;
+	border-radius: var(--radius-s, 5px);
+	border: 1px solid transparent;
+	transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+	font-size: var(--font-ui-small, 13px);
+	line-height: 1.4;
+	color: var(--text-normal);
+}
+
+.pin-to-top-item .nav-file-title-content,
+.pin-to-top-item .nav-folder-title-content {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 1;
+	min-width: 0;
+}
+
+/* Hover State */
+.pin-to-top-item:hover > .nav-file-title,
+.pin-to-top-item:hover > .nav-folder-title {
+	background-color: var(--background-modifier-hover);
+	border-color: var(
+		--background-modifier-border-hover,
+		var(--background-modifier-border)
+	);
+}
+
+/* Active / Selected State */
+.pin-to-top-item.is-active > .nav-file-title,
+.pin-to-top-item.is-active > .nav-folder-title {
+	background-color: var(--background-modifier-hover);
+	color: var(--text-accent);
+	border-left: 2px solid var(--interactive-accent);
+	padding-left: 6px;
+	font-weight: 500;
+}
+
+/* ===== Drag & Drop ===== */
+.pin-to-top-item.pin-dragging {
+	opacity: 0.4;
+	transform: scale(0.97);
+}
+
+.pin-to-top-item.pin-dragging > .nav-file-title,
+.pin-to-top-item.pin-dragging > .nav-folder-title {
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.pin-to-top-item.pin-drag-over {
+	position: relative;
+}
+
+.pin-to-top-item.pin-drag-over > .nav-file-title,
+.pin-to-top-item.pin-drag-over > .nav-folder-title {
+	background-color: var(--background-modifier-hover);
+}
+
+/* Animated drop indicator line */
+.pin-to-top-item.pin-drag-over::after {
+	content: "";
+	position: absolute;
+	top: -1px;
+	left: 8px;
+	right: 8px;
+	height: 2px;
+	background-color: var(--interactive-accent);
+	border-radius: 1px;
+	z-index: 1;
+	animation: pin-drop-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pin-drop-pulse {
+	0%,
+	100% {
+		opacity: 0.6;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+
+/* ===== Pin Icon for Top Pinned Items ===== */
 body.pin-to-top-show-pinned-top-icon
 	.pin-to-top-container
 	> .pin-to-top-item
@@ -24,59 +161,30 @@ body.pin-to-top-show-pinned-top-icon
 	display: inline-block;
 	width: 14px;
 	height: 14px;
-	margin-right: 6px;
-	vertical-align: middle;
-	background-image: url('data:image/svg+xml;utf8,<svg fill="%23999999" viewBox="0 0 489.493 489.493" xmlns="http://www.w3.org/2000/svg"><path d="M485.322,117.705c12.204-12.238-3.274-47.577-34.636-78.93c-30.99-30.99-65.76-46.396-78.401-34.941l-0.246-0.236 l-173.715,156.02c-32.117-27.993-80.684-27.038-111.278,3.534c-5.149,5.157-8.051,12.146-8.051,19.437 c0,7.292,2.901,14.283,8.051,19.431l78.808,78.801L3.902,463.627c-5.148,5.799-5.262,14.655,0.015,20.601 c5.689,6.403,15.497,6.992,21.916,1.294l182.575-162.137l7.84,7.829l40.601,40.603l0,0l30.336,30.329 c5.15,5.147,12.139,8.039,19.424,8.039c7.278,0,14.272-2.898,19.419-8.056c30.561-30.573,31.524-79.158,3.539-111.27L484.771,118.03 C484.927,117.892,485.177,117.861,485.322,117.705z"/></svg>');
-	background-size: contain;
-	background-repeat: no-repeat;
-	background-position: center;
-	opacity: 0.7;
+	margin-right: 7px;
+	flex-shrink: 0;
+	background-color: var(--text-accent);
+	-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M16 12V4H17V2H7V4H8V12L6 14V16H11.2V22H12.8V16H18V14L16 12Z"/></svg>');
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+	-webkit-mask-size: contain;
+	mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M16 12V4H17V2H7V4H8V12L6 14V16H11.2V22H12.8V16H18V14L16 12Z"/></svg>');
+	mask-repeat: no-repeat;
+	mask-position: center;
+	mask-size: contain;
+	opacity: 0.75;
+	transition:
+		opacity 0.2s ease,
+		transform 0.2s ease;
 }
 
-/* Subtle highlight for pinned items in the container */
-.pin-to-top-container > .pin-to-top-item > .nav-file-title,
-.pin-to-top-container > .pin-to-top-item > .nav-folder-title {
-	background-color: var(--background-modifier-hover);
-	border-radius: 4px;
+.pin-to-top-item:hover > .nav-file-title::before,
+.pin-to-top-item:hover > .nav-folder-title::before {
+	opacity: 1 !important;
+	transform: scale(1.1);
 }
 
-/* Style pinned items to look clickable */
-.pin-to-top-item {
-	cursor: pointer;
-	transition: opacity 0.2s, transform 0.2s;
-}
-
-.pin-to-top-item .nav-folder-title,
-.pin-to-top-item .nav-file-title {
-	padding: 2px 6px;
-}
-
-/* Drag and drop states */
-.pin-to-top-item.pin-dragging {
-	opacity: 0.4;
-}
-
-.pin-to-top-item.pin-drag-over {
-	border-top: 2px solid var(--interactive-accent);
-	margin-top: -2px;
-}
-
-/* Show draggable cursor on hover */
-.pin-to-top-item:hover {
-	cursor: grab;
-}
-
-.pin-to-top-item:active {
-	cursor: grabbing;
-}
-
-/* Hide collapse indicator for pinned folders (they act as links) */
-.pin-to-top-item .nav-folder-collapse-indicator {
-	display: none;
-}
-
-/* Mark original pinned items with a subtle indicator */
-/* Works for both items in folders and root-level items */
+/* ===== Main Explorer Pin Indicator ===== */
 body.pin-to-top-show-main-explorer-pin-icon
 	.pin-to-top-pinned
 	> .nav-file-title
@@ -90,20 +198,41 @@ body.pin-to-top-show-main-explorer-pin-icon
 	height: 10px;
 	margin-left: 6px;
 	vertical-align: middle;
-	background-image: url('data:image/svg+xml;utf8,<svg fill="%23999999" viewBox="0 0 489.493 489.493" xmlns="http://www.w3.org/2000/svg"><path d="M485.322,117.705c12.204-12.238-3.274-47.577-34.636-78.93c-30.99-30.99-65.76-46.396-78.401-34.941l-0.246-0.236 l-173.715,156.02c-32.117-27.993-80.684-27.038-111.278,3.534c-5.149,5.157-8.051,12.146-8.051,19.437 c0,7.292,2.901,14.283,8.051,19.431l78.808,78.801L3.902,463.627c-5.148,5.799-5.262,14.655,0.015,20.601 c5.689,6.403,15.497,6.992,21.916,1.294l182.575-162.137l7.84,7.829l40.601,40.603l0,0l30.336,30.329 c5.15,5.147,12.139,8.039,19.424,8.039c7.278,0,14.272-2.898,19.419-8.056c30.561-30.573,31.524-79.158,3.539-111.27L484.771,118.03 C484.927,117.892,485.177,117.861,485.322,117.705z"/></svg>');
-	background-size: contain;
-	background-repeat: no-repeat;
-	background-position: center;
-	opacity: 0.4;
+	background-color: var(--text-muted);
+	-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M16 12V4H17V2H7V4H8V12L6 14V16H11.2V22H12.8V16H18V14L16 12Z"/></svg>');
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+	-webkit-mask-size: contain;
+	mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M16 12V4H17V2H7V4H8V12L6 14V16H11.2V22H12.8V16H18V14L16 12Z"/></svg>');
+	mask-repeat: no-repeat;
+	mask-position: center;
+	mask-size: contain;
+	opacity: 0.35;
+	transition: opacity 0.2s ease;
 }
 
-/* Settings tab styles */
+/* ===== Cursor States ===== */
+.pin-to-top-item {
+	cursor: grab;
+}
+
+.pin-to-top-item:active {
+	cursor: grabbing;
+}
+
+/* Hide collapse indicator for pinned folders */
+.pin-to-top-item .nav-folder-collapse-indicator {
+	display: none;
+}
+
+/* ===== Settings Tab Styles ===== */
 .pin-to-top-settings-list {
 	margin-top: 10px;
 	border: 1px solid var(--background-modifier-border);
-	border-radius: 4px;
+	border-radius: var(--radius-m, 6px);
 	max-height: 300px;
 	overflow-y: auto;
+	background: var(--background-primary);
 }
 
 .pin-to-top-settings-item {
@@ -112,6 +241,11 @@ body.pin-to-top-show-main-explorer-pin-icon
 	align-items: center;
 	padding: 8px 12px;
 	border-bottom: 1px solid var(--background-modifier-border);
+	transition: background-color 0.15s ease;
+}
+
+.pin-to-top-settings-item:hover {
+	background-color: var(--background-modifier-hover);
 }
 
 .pin-to-top-settings-item:last-child {
@@ -126,8 +260,12 @@ body.pin-to-top-show-main-explorer-pin-icon
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	margin-right: 10px;
+	color: var(--text-normal);
 }
 
 .pin-to-top-unpin-button {
 	flex-shrink: 0;
+	font-size: var(--font-ui-smaller);
+	padding: 4px 10px;
+	border-radius: var(--radius-s, 4px);
 }

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,8 @@ body.pin-to-top-keep-pinned-items-visible .pin-to-top-container {
 	top: 0;
 	z-index: 10;
 	background-color: var(--background-primary);
+	padding: 6px 0px 0px !important;
+	border-radius: 4px;
 }
 
 /* ===== Section Header ===== */


### PR DESCRIPTION
## Summary

  This PR updates the Pin to Top plugin with several usability and persistence fixes, plus a broader visual polish pass.

  ### Fixes
  - Fixes the startup bug where pinned settings could be cleared on Obsidian restart
  - Stops eagerly pruning pinned items before the vault is fully available
  - Removes file extensions from pinned note labels in the pinned section

  ### New settings
  - Show or hide the pinned section header
  - Keep pinned items visible while scrolling
  - Show or hide the pin icon before pinned items in the top section
  - Show or hide the pin icon after pinned items in the main explorer

  ### UI and styling improvements
  - Improves the pinned section styling and spacing
  - Adds a clearer pinned header presentation
  - Refines pinned item hover, active, and drag-and-drop states
  - Makes the pinned section feel more integrated with the file explorer

  ### Behavior changes
  - Pinned items now use the note basename in the pinned list instead of the full filename
  - Sticky pinned items are opt-in and disabled by default to preserve current behavior

  ## Testing

  - `npm run build`
  - Verified settings persist across reloads
  - Verified the pinned section still refreshes correctly after pin/unpin, rename, and delete actions

  ## Notes

  - This PR is backwards compatible with existing saved settings
  - No changes were made to the plugin ID or manifest identity